### PR TITLE
Bump package build action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: pytest
 
       - name: Build sdist
-        run: python -m build ./backend
+        run: python -m build ./backend --sdist
 
       - name: Publish sdist
         uses: actions/upload-artifact@v4

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,8 +44,11 @@ jobs:
         working-directory: ./backend
         run: pytest
 
-      - name: Inspect 
-        uses: hynek/build-and-inspect-python-package@v2.1.0
+      - name: Build sdist
+        run: python -m build ./backend
+
+      - name: Publish sdist
+        uses: actions/upload-artifact@v4
         with:
-          path: ./backend
-          skip-wheel: 'true'
+          name: sdist
+          path: 'backend/dist/*''

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
         run: pytest
 
       - name: Inspect 
-        uses: hynek/build-and-inspect-python-package@v2.0.2
+        uses: hynek/build-and-inspect-python-package@v2.1.0
         with:
           path: ./backend
           skip-wheel: 'true'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,5 +50,5 @@ jobs:
       - name: Publish sdist
         uses: actions/upload-artifact@v4
         with:
-          name: cyton
+          name: sdist
           path: 'backend/dist/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,4 +51,4 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           name: sdist
-          path: 'backend/dist/*''
+          path: 'backend/dist/*'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,5 +50,5 @@ jobs:
       - name: Publish sdist
         uses: actions/upload-artifact@v4
         with:
-          name: sdist
+          name: cyton
           path: 'backend/dist/*'

--- a/backend/pyproject.toml
+++ b/backend/pyproject.toml
@@ -20,7 +20,7 @@ dependencies = [
 ]
 
 [project.optional-dependencies]
-dev = ["pytest"]
+dev = ["pytest", "build"]
 server = ["uvicorn"]
 
 [project.scripts]


### PR DESCRIPTION
Refactor the CI build process to directly publish the sdist. This should make installation of draft versions a bit easier.